### PR TITLE
Version 0.89

### DIFF
--- a/LRTimelapse_Pro_Timer_Free/EEPROMConfig.cpp
+++ b/LRTimelapse_Pro_Timer_Free/EEPROMConfig.cpp
@@ -1,0 +1,90 @@
+/*
+   Klaus Heiss
+   www.elite.at
+   Aug. 2017
+*/
+
+#include "EEPROMConfig.h"
+#include <EEPROM.h>
+
+void EEPParams::SerialPrintParams() {
+  #ifdef debug
+    String str = "";
+    str = "Background brightness level = "; str += Params.BackgroundBrightnessLevel;  Serial.println(str);
+    str = "Interval                    = "; str += Params.Interval;  Serial.println(str);
+  #endif
+}
+
+boolean EEPParams::ParamsWrite() {
+  #ifdef debug
+    Serial.println("=== Write Params to EEPROM if changed ===");
+  #endif
+  EEPParamsStru epp;
+  EEPROM.get(0,epp);
+  if ( (Params.SumBytes                  != epp.SumBytes) ||    
+       (Params.BackgroundBrightnessLevel != epp.BackgroundBrightnessLevel) ||
+       (Params.Interval                  != epp.Interval) ||
+       (Params.SumBytesXored             != epp.SumBytesXored) ) {
+    crcOK();  // calcs & sets CRCSumBytes
+    Params.SumBytes =      CRCSumBytes;
+    Params.SumBytesXored = CRCSumBytes^0xFFFF;
+    EEPROM.put(0,Params);
+    #ifdef debug
+      SerialPrintParams();
+      Serial.println("wrote Params into EEPROM.");
+    #endif
+    return true;
+  } else {
+    #ifdef debug
+      Serial.println("params didn't change.");
+    #endif
+    return false;
+  }
+}
+
+boolean EEPParams::ParamsRead() {
+  #ifdef debug
+    Serial.println("=== Read Params from EEPROM ===");
+  #endif
+  // read Params fromEEPROM
+  EEPROM.get(0,Params); 
+  boolean retval = crcOK(); 
+  if (retval) {
+    #ifdef debug
+      Serial.println("EEPROM Params (crc) OK");
+    #endif
+  } else {
+    SerialPrintParams();
+    Params = EEPParamsDefault;
+    #ifdef debug
+      Serial.println("EEPROM Params CRC WRONG - uses defaults");
+    #endif
+  }
+  SerialPrintParams();
+  return retval;
+}
+
+boolean EEPParams::crcOK() {
+  int len = sizeof(Params);     //12abbbb12    len=9 -4 = 5
+  byte * pb;
+  pb = (byte *) & Params;
+  pb += 2;
+  CRCSumBytes = 0;
+  for (int i=0; i < (len-4); i++) {
+    CRCSumBytes += *pb++;
+  }
+  #ifdef debug
+    Serial.println("=== Calc Params crc ===");
+    String str = "";
+    str = "Size Of Params= "; str += len;  Serial.println(str);
+    
+    str = "Params.SumBytes      = "; str += String(Params.SumBytes, HEX); Serial.println(str);
+    str = "Calced SumBytes      = "; str += String(CRCSumBytes, HEX); Serial.println(str);
+    
+    str = "Params.SumXORedBytes = "; str += String(Params.SumBytesXored, HEX); Serial.println(str);
+    str = "Calced SumXORedBytes = "; str += String(CRCSumBytes^0xFFFF, HEX); Serial.println(str);
+  #endif
+  boolean res = (CRCSumBytes == Params.SumBytes) && ((CRCSumBytes^0xFFFF) == Params.SumBytesXored);
+  return res;
+}
+

--- a/LRTimelapse_Pro_Timer_Free/EEPROMConfig.h
+++ b/LRTimelapse_Pro_Timer_Free/EEPROMConfig.h
@@ -1,0 +1,37 @@
+/*
+   Klaus Heiss
+   www.elite.at
+   Aug. 2017
+*/
+
+#ifndef __EEPROM_Config__
+#define __EEPROM_Config__
+
+#include <Arduino.h>
+
+// #define debug
+#undef debug
+
+//                                        N/A   BGL:0..5  interval   N/A
+#define EEPParamsDefault (EEPParamsStru) { 0,          4,      4.0,   0 };
+
+struct EEPParamsStru {
+  unsigned int SumBytes;                      // 2
+  byte         BackgroundBrightnessLevel;     // 1
+  float        Interval;                      // 4
+  unsigned int SumBytesXored;                 // 2
+};                                            // 9 Bytes
+
+class EEPParams {
+  private:
+    unsigned int CRCSumBytes;
+    boolean crcOK();
+    void SerialPrintParams();
+  public:
+    EEPParamsStru Params;
+    boolean ParamsRead();
+    boolean ParamsWrite();
+    
+};
+
+#endif

--- a/LRTimelapse_Pro_Timer_Free/LCD_Keypad_Reader.cpp
+++ b/LRTimelapse_Pro_Timer_Free/LCD_Keypad_Reader.cpp
@@ -12,31 +12,36 @@
 
 static int DEFAULT_KEY_PIN = 0;
 
-// The Sainsmart keypad uses a voltage divider to deliver a voltage
-// between 0 and 5 V that corresponds to the key being pressed in
-// order to use only a single input pin. The values below are from 0 to
-// 1023 because the Arduino uses a 10 bit resolution.
-/* Board introduced by G.W.   */
-static int DEFAULT_THRESHOLD = 50;   // KH: changed from 5 to 50 - more tolerance
-static int UPKEY_ARV = 144; // 0.720 V, that's read "analogue read value"
-static int DOWNKEY_ARV = 329; // 1.645 V
-static int LEFTKEY_ARV = 505; // 2.525 V
-static int RIGHTKEY_ARV = 0; // 0 V
-static int SELKEY_ARV = 742; // 3.710 V
-static int NOKEY_ARV = 1023; // 5.115 V
-/* */
+#define _display_standard_
+// #define _display_alternative1_
 
-/* K.H.: My NEW Board (looks same as that one shown in project, but branded as: Open Source ELECTRONICS - Miroad
- *       has other voltage steps - here the values:    */
-/*  IF ONLY THE RIGHT-KEY IS RECOGNIZED ON YOUR BOARD,  TRY THIS VALUES
-static int DEFAULT_THRESHOLD = 50;
-static int UPKEY_ARV = 99;
-static int DOWNKEY_ARV = 256;
-static int LEFTKEY_ARV = 410;
-static int RIGHTKEY_ARV = 0;
-static int SELKEY_ARV = 640;
-static int NOKEY_ARV = 1023;
-*/
+#ifdef _display_standard_
+  // The Sainsmart keypad uses a voltage divider to deliver a voltage
+  // between 0 and 5 V that corresponds to the key being pressed in
+  // order to use only a single input pin. The values below are from 0 to
+  // 1023 because the Arduino uses a 10 bit resolution.
+  /* Board introduced by G.W.   */
+  static int DEFAULT_THRESHOLD = 50;   // KH: changed from 5 to 50 - more tolerance
+  static int UPKEY_ARV = 144; // 0.720 V, that's read "analogue read value"
+  static int DOWNKEY_ARV = 329; // 1.645 V
+  static int LEFTKEY_ARV = 505; // 2.525 V
+  static int RIGHTKEY_ARV = 0; // 0 V
+  static int SELKEY_ARV = 742; // 3.710 V
+  static int NOKEY_ARV = 1023; // 5.115 V
+#endif
+
+#ifdef _display_alternative1_
+  // K.H.: My NEW Board (looks same as that one shown in project, but branded as: Open Source ELECTRONICS - Miroad
+  //       has other voltage steps - here the values:  
+  //  IF ONLY THE RIGHT-KEY IS RECOGNIZED ON YOUR BOARD,  TRY THIS VALUES 
+  static int DEFAULT_THRESHOLD = 50;
+  static int UPKEY_ARV = 99;
+  static int DOWNKEY_ARV = 256;
+  static int LEFTKEY_ARV = 410;
+  static int RIGHTKEY_ARV = 0;
+  static int SELKEY_ARV = 640;
+  static int NOKEY_ARV = 1023;
+#endif
 
 LCD_Keypad_Reader::LCD_Keypad_Reader()
 {

--- a/LRTimelapse_Pro_Timer_Free/LRTimelapse_Pro_Timer_Free.ino
+++ b/LRTimelapse_Pro_Timer_Free/LRTimelapse_Pro_Timer_Free.ino
@@ -4,13 +4,16 @@
   http://gwegner.de
   http://lrtimelapse.com
 
+  Version 0.89: Klaus Heiss: Lcd backlight dimming implemented, Save Params in EEPROM implemented (lib EEPROMConfig) 28.08.17
   Version 0.88: Thanks for Klaus Heiss (KH) for implementing the dynamic key rate
 */
 
+
 #include <LiquidCrystal.h>
 #include "LCD_Keypad_Reader.h"			// credits to: http://www.hellonull.com/?p=282
+#include "EEPROMConfig.h"           // Klaus Heiss, www.elite.at
 
-const String CAPTION = "Pro-Timer 0.88";
+const String CAPTION = "Pro-Timer 0.89";
 
 LCD_Keypad_Reader keypad;
 LiquidCrystal lcd(8, 9, 4, 5, 6, 7);	//Pin assignments for SainSmart LCD Keypad Shield
@@ -22,7 +25,8 @@ const int UP = 3;
 const int DOWN = 4;
 const int RIGHT = 5;
 
-const int BACK_LIGHT = 10;
+const int Onboard_LED = 13;
+const int BACK_LIGHT  = 10;
 
 const float RELEASE_TIME_DEFAULT = 0.1;			// default shutter release time for camera
 const float MIN_DARK_TIME = 0.5;
@@ -34,6 +38,7 @@ int lastKeyPressed = -1;				// The last pressed key
 
 unsigned long lastKeyCheckTime = 0;
 unsigned long lastKeyPressTime = 0;
+unsigned long lastDispTurnedOffTime = 0;
 
 int sameKeyCount = 0;
 float releaseTime = RELEASE_TIME_DEFAULT;			        // Shutter release time for camera
@@ -79,29 +84,62 @@ int currentMenu = 0;					// the currently selected menu
 int settingsSel = 1;					// the currently selected settings option
 int mode = MODE_M;            // mode: M or Bulb
 
+const float cMinInterval = 0.2;
+const float cMaxInterval = 99;  // no intervals longer as 99secs - those would scramble the display
+
+// K.H. LCD dimming
+const int cMinLevel     = 0;  // Min. Background Brightness Levels
+const int cMaxLevel     = 5;  // Max. Background Brightness Levels
+int  act_BackLightLevel = 4;
+char act_BackLightDir   = 'D';
+
+// K.H: EPROM Params 
+EEPParams EEProm;
+
+
 /**
    Initialize everything
 */
 void setup() {
+  pinMode(Onboard_LED, OUTPUT);
+  digitalWrite(Onboard_LED, LOW);   // Turn Onboard LED OFF. it only consumes battery power ;-)
 
   pinMode(BACK_LIGHT, OUTPUT);
-  digitalWrite(BACK_LIGHT, HIGH);		// Turn backlight on.
+  digitalWrite(BACK_LIGHT, LOW);    // First turn backlight off.
 
+  Serial.begin(9600);
+  Serial.println( CAPTION );
+
+  // init LCD display
   lcd.begin(16, 2);
   lcd.clear();
   lcd.setCursor(0, 0);
-
   // print welcome screen))
   lcd.print("LRTimelapse.com");
   lcd.setCursor(0, 1);
   lcd.print( CAPTION );
 
-  pinMode(12, OUTPUT);					// initialize output pin for camera release
+  // Load EEPROM params
+  EEProm.ParamsRead();
+  // check ranges
+  EEProm.Params.BackgroundBrightnessLevel = constrain(EEProm.Params.BackgroundBrightnessLevel, cMinLevel,    cMaxLevel);
+  EEProm.Params.Interval                  = constrain(EEProm.Params.Interval,                  cMinInterval, cMaxInterval);
+  
+  act_BackLightLevel = EEProm.Params.BackgroundBrightnessLevel;
+  interval           = EEProm.Params.Interval;
+  
+  // wait a moment...  show CAPTION dimming
+  /* H.K.: implemented dimming */  
+  digitalWrite(BACK_LIGHT, HIGH);    // Turn backlight on.
+  delay(1500);
+  DimLCD(255,0,2);
 
-  delay(2000);							// wait a moment...
 
-  Serial.begin(9600);
-  Serial.println( CAPTION );
+  printIntervalMenu();
+  delay(250);
+  DimLCD(0,act_BackLightBrightness(),2);
+
+  pinMode(12, OUTPUT);          // initialize output pin for camera release
 
   lcd.clear();
 }
@@ -110,7 +148,6 @@ void setup() {
    The main loop
 */
 void loop() {
-
   if (millis() > lastKeyCheckTime + keySampleRate) {
     lastKeyCheckTime = millis();
     localKey = keypad.getKey();
@@ -127,7 +164,7 @@ void loop() {
       /* H.K.: implemented function ActRepeateRate instead of constant */
       if (localKey != 0 && millis() > lastKeyPressTime + keypad.ActRepeatRate()) {
         // yes, repeat this key
-        if ( (localKey == UP ) || ( localKey == DOWN ) ) {
+        if ( (localKey == UP ) || ( localKey == DOWN ) || ( localKey == SELECT ) ) {
           processKey();
         }
       }
@@ -136,12 +173,12 @@ void loop() {
     if ( currentMenu == SCR_RUNNING ) {
       printScreen();	// update running screen in any case
 
-      if( mode == MODE_BULB ){
+      if ( mode == MODE_BULB ) {
         possiblyEndLongExposure(); // checks regularly if a long exposure has to be cancelled
       }
     }
 
-    if( currentMenu == SCR_SINGLE ){
+    if ( currentMenu == SCR_SINGLE ) {
       possiblyEndLongExposure();
     }
 
@@ -152,22 +189,135 @@ void loop() {
 
 }
 
+
+/* 
+  K.H: dimming LCD BAckground light
+*/
+void DimLCD( byte startval, byte endval, byte stepdelay) {
+  if (endval < startval) {
+    for ( int bl = startval; bl >= endval; bl--) {
+      analogWrite(BACK_LIGHT, bl);    // dimming backlight off.
+      delay(stepdelay);
+    }
+  }
+  else {
+    for ( int bl = startval; bl <= endval; bl++) {
+      analogWrite(BACK_LIGHT, bl);    // dimming backlight off.
+      delay(stepdelay);
+    }
+  }  
+}
+
+/**
+  K.H: Change Backlight Brightness in Steps
+*/
+void changeBackLightBrightness( char AMode) {   //U=up, D=douwn, R=rolling
+  if ((AMode == 'U') || (AMode == 'D')) {
+    act_BackLightDir = AMode;
+  }
+  if (act_BackLightDir == 'D') {
+    act_BackLightLevel --;
+  } else {
+    act_BackLightLevel ++;
+  }
+
+  if ((act_BackLightLevel == -1) && (AMode == 'R')) {
+    act_BackLightDir = 'U';
+  }
+  if ((act_BackLightLevel == cMaxLevel + 1)  && (AMode == 'R')) {
+    act_BackLightDir = 'D';
+  }
+  if (AMode == 'R') {
+    act_BackLightLevel = constrain(act_BackLightLevel, cMinLevel - 1, cMaxLevel + 1);
+  } else {
+    act_BackLightLevel = constrain(act_BackLightLevel, cMinLevel, cMaxLevel);
+  }
+
+  analogWrite(BACK_LIGHT, act_BackLightBrightness()); // Turn PWM backlight on.
+}
+
+/**
+  K.H. calc PWM-Value for background display brightness
+*/
+byte act_BackLightBrightness() {
+  return constrain (act_BackLightLevel * (255 / cMaxLevel), 12, 255);
+}
+
+/**
+   K.H. save actual level in EPROM
+*/
+void save_Params() {
+  String str;
+  if (not isRunning) {
+    boolean save = false;
+    act_BackLightLevel = constrain(act_BackLightLevel, cMinLevel, cMaxLevel);
+    if (act_BackLightLevel != EEProm.Params.BackgroundBrightnessLevel) {
+      str = "saved level "; str += (act_BackLightLevel + 1); str += "   "; 
+      lcd.setCursor(0, 0);
+      lcd.print(str);
+      delay(2000);
+      save = true;
+    };
+    if (interval != EEProm.Params.Interval) {
+      str = "saved int. "; str += String(interval, 2); str += "  "; 
+      lcd.setCursor(0, 0);
+      lcd.print(str);
+      delay(2000);
+      save = true;
+    };
+    if (save) {
+      EEProm.Params.BackgroundBrightnessLevel = act_BackLightLevel;
+      EEProm.Params.Interval                  = interval;
+      if (not EEProm.ParamsWrite()) {
+        lcd.setCursor(0, 0); lcd.print("PROBLEM SAVING  ");
+        lcd.setCursor(0, 1); lcd.print("PARAMS TO EEPROM");
+        delay(3000);
+        lcd.clear();
+      }
+    } else {  
+      lcd.setCursor(0, 0);
+      lcd.print("OK, no changes");
+      delay(1500);
+    }
+    lcd.setCursor(0, 0);
+    lcd.print("                ");
+  }
+}
+
 /**
    Process the key presses - do the Menu Navigation
 */
 void processKey() {
 
-  lastKeyPressed = localKey;
-  lastKeyPressTime = millis();
-
   // select key will switch backlight at any time
   if ( localKey == SELECT ) {
-    if ( backLight == HIGH ) {
-      backLight = LOW;
-    } else {
-      backLight = HIGH;
+    if (lastKeyPressed == SELECT) {
+      if (millis() > lastKeyPressTime + 500) {
+        changeBackLightBrightness('R');
+        lastKeyPressTime = millis();
+        backLight = true;
+      }
     }
-    digitalWrite(BACK_LIGHT, backLight); // Turn backlight on.
+    else {
+      backLight = !backLight;
+      if (backLight) {
+        analogWrite(BACK_LIGHT, act_BackLightBrightness()); // Turn PWM backlight on.
+        if (millis() < lastDispTurnedOffTime + 450) {
+          save_Params();
+          lastDispTurnedOffTime = 0;
+        }
+      }
+      else {
+        digitalWrite(BACK_LIGHT, LOW); // Turn backlight off.
+        lastDispTurnedOffTime = millis();
+      }
+      lastKeyPressed = localKey;
+      lastKeyPressTime = millis();
+    }
+  }
+  else {
+    lastKeyPressed = localKey;
+    lastKeyPressTime = millis();
   }
 
   // do the menu navigation
@@ -177,13 +327,13 @@ void processKey() {
 
       if ( localKey == UP ) {
         interval = (float)((int)(interval * 10) + 1) / 10; // round to 1 decimal place
-        if ( interval > 99 ) { // no intervals longer as 99secs - those would scramble the display
-          interval = 99;
+        if ( interval > cMaxInterval ) { 
+          interval = cMaxInterval;
         }
       }
 
       if ( localKey == DOWN ) {
-        if ( interval > 0.2) {
+        if ( interval > cMinInterval) {
           interval = (float)((int)(interval * 10) - 1) / 10; // round to 1 decimal place
         }
       }
@@ -203,13 +353,13 @@ void processKey() {
 
     case SCR_MODE:
       if ( localKey == RIGHT ) {
-          currentMenu = SCR_SHOTS;
+        currentMenu = SCR_SHOTS;
       }
-      else if( localKey == LEFT ){
+      else if ( localKey == LEFT ) {
         currentMenu = SCR_INTERVAL;
       }
-      else if( ( localKey == UP ) || ( localKey == DOWN ) ){
-        if( mode == MODE_M ){
+      else if ( ( localKey == UP ) || ( localKey == DOWN ) ) {
+        if ( mode == MODE_M ) {
           mode = MODE_BULB;
         } else {
           mode = MODE_M;
@@ -260,7 +410,7 @@ void processKey() {
       }
 
       if ( localKey == RIGHT ) { // Start shooting
-        if( mode == MODE_M ){
+        if ( mode == MODE_M ) {
           currentMenu = SCR_RUNNING;
           firstShutter();
         } else {
@@ -269,33 +419,33 @@ void processKey() {
       }
       break;
 
-      // Exposure Time
-      case SCR_EXPOSURE:
+    // Exposure Time
+    case SCR_EXPOSURE:
 
-        if ( localKey == UP ) {
-          releaseTime = (float)((int)(releaseTime * 10) + 1) / 10; // round to 1 decimal place
+      if ( localKey == UP ) {
+        releaseTime = (float)((int)(releaseTime * 10) + 1) / 10; // round to 1 decimal place
+      }
+
+      if ( releaseTime > interval - MIN_DARK_TIME ) { // no release times longer then (interval-Min_Dark_Time)
+        releaseTime = interval - MIN_DARK_TIME;
+      }
+
+      if ( localKey == DOWN ) {
+        if ( releaseTime > RELEASE_TIME_DEFAULT ) {
+          releaseTime = (float)((int)(releaseTime * 10) - 1) / 10; // round to 1 decimal place
         }
+      }
 
-        if ( releaseTime > interval - MIN_DARK_TIME ) { // no release times longer then (interval-Min_Dark_Time)
-          releaseTime = interval - MIN_DARK_TIME;
-        }
+      if ( localKey == LEFT ) {
+        currentMenu = SCR_SHOTS;
+      }
 
-        if ( localKey == DOWN ) {
-          if ( releaseTime > RELEASE_TIME_DEFAULT ) {
-            releaseTime = (float)((int)(releaseTime * 10) - 1) / 10; // round to 1 decimal place
-          }
-        }
+      if ( localKey == RIGHT ) {
+        currentMenu = SCR_RUNNING;
+        firstShutter();
+      }
 
-        if ( localKey == LEFT ) {
-          currentMenu = SCR_SHOTS;
-        }
-
-        if ( localKey == RIGHT ) {
-          currentMenu = SCR_RUNNING;
-          firstShutter();
-        }
-
-        break;
+      break;
 
     case SCR_RUNNING:
 
@@ -319,13 +469,20 @@ void processKey() {
         currentMenu = SCR_SETTINGS;
         lcd.clear();
       }
+
+      if ( localKey == UP ) {
+        changeBackLightBrightness('U');
+      }
+      if ( localKey == DOWN ) {
+        changeBackLightBrightness('D');
+      }
       break;
 
     case SCR_CONFIRM_END:
       if ( localKey == LEFT ) { // Really abort
         currentMenu = SCR_INTERVAL;
 
-        if( bulbReleasedAt > 0 ){ // if we are shooting in bulb mode, instantly stop the exposure
+        if ( bulbReleasedAt > 0 ) { // if we are shooting in bulb mode, instantly stop the exposure
           bulbReleasedAt = 0;
           digitalWrite(12, LOW);
         }
@@ -418,13 +575,13 @@ void processKey() {
 
       if ( localKey == UP ) {
         rampTo = (float)((int)(rampTo * 10) + 1) / 10; // round to 1 decimal place
-        if ( rampTo > 99 ) { // no intervals longer as 99secs - those would scramble the display
-          rampTo = 99;
+        if ( rampTo > cMaxInterval ) { 
+          rampTo = cMaxInterval;
         }
       }
 
       if ( localKey == DOWN ) {
-        if ( rampTo > 0.2) {
+        if ( rampTo > cMinInterval) {
           rampTo = (float)((int)(rampTo * 10) - 1) / 10; // round to 1 decimal place
         }
       }
@@ -453,7 +610,7 @@ void processKey() {
 
     case SCR_SINGLE:
       if ( localKey == UP ) {
-        if( releaseTime < 60 )
+        if ( releaseTime < 60 )
           releaseTime = (float)((int)(releaseTime + 1));
         else
           releaseTime = (float)((int)(releaseTime + 10));
@@ -461,12 +618,12 @@ void processKey() {
 
       if ( localKey == DOWN ) {
         if ( releaseTime > RELEASE_TIME_DEFAULT ) {
-          if( releaseTime < 60 )
+          if ( releaseTime < 60 )
             releaseTime = (float)((int)(releaseTime - 1));
           else
             releaseTime = (float)((int)(releaseTime - 10));
         }
-        if( releaseTime < RELEASE_TIME_DEFAULT ){ // if it's too short after decrementing, set to the default release time.
+        if ( releaseTime < RELEASE_TIME_DEFAULT ) { // if it's too short after decrementing, set to the default release time.
           releaseTime = RELEASE_TIME_DEFAULT;
         }
       }
@@ -478,42 +635,42 @@ void processKey() {
 
       if ( localKey == RIGHT ) {
         lcd.clear();
-        if( bulbReleasedAt == 0 ){   // if not running, go to main screen
+        if ( bulbReleasedAt == 0 ) { // if not running, go to main screen
           currentMenu = SCR_INTERVAL;
         } else {                     // if running, go to confirm screen
           currentMenu = SCR_CONFIRM_END_BULB;
         }
 
       }
-    break;
+      break;
 
     case SCR_CONFIRM_END_BULB:
-        if ( localKey == RIGHT ) { // Really abort
+      if ( localKey == RIGHT ) { // Really abort
 
-          digitalWrite(12, LOW);
-          stopShooting();
+        digitalWrite(12, LOW);
+        stopShooting();
 
-          currentMenu = SCR_SINGLE;
-          lcd.clear();
-        }
-        if ( localKey == LEFT ) { // resume
-          currentMenu = SCR_SINGLE;
-          lcd.clear();
-        }
-        break;
+        currentMenu = SCR_SINGLE;
+        lcd.clear();
+      }
+      if ( localKey == LEFT ) { // resume
+        currentMenu = SCR_SINGLE;
+        lcd.clear();
+      }
+      break;
 
   }
   printScreen();
 }
 
-void stopShooting(){
+void stopShooting() {
   isRunning = 0;
   imageCount = 0;
   runningTime = 0;
   bulbReleasedAt = 0;
 }
 
-void firstShutter(){
+void firstShutter() {
   previousMillis = millis();
   runningTime = 0;
   isRunning = 1;
@@ -581,6 +738,7 @@ void printScreen() {
     case SCR_SINGLE:
       printSingleScreen();
       break;
+
   }
 }
 
@@ -620,7 +778,7 @@ void possiblyRampInterval() {
   if ( ( millis() < rampingEndTime ) && ( millis() >= rampingStartTime ) ) {
     interval = intervalBeforeRamping + ( (float)( millis() - rampingStartTime ) / (float)( rampingEndTime - rampingStartTime ) * ( rampTo - intervalBeforeRamping ) );
 
-    if( releaseTime > interval - MIN_DARK_TIME ){ // if ramping makes the interval too short for the exposure time in bulb mode, adjust the exposure time
+    if ( releaseTime > interval - MIN_DARK_TIME ) { // if ramping makes the interval too short for the exposure time in bulb mode, adjust the exposure time
       releaseTime =  interval - MIN_DARK_TIME;
     }
 
@@ -636,8 +794,8 @@ void possiblyRampInterval() {
 void releaseCamera() {
 
   // short trigger in M-Mode
-  if( releaseTime < 1 ){
-    if( currentMenu == SCR_RUNNING ){ // display exposure indicator on running screen only
+  if ( releaseTime < 1 ) {
+    if ( currentMenu == SCR_RUNNING ) { // display exposure indicator on running screen only
       lcd.setCursor(7, 1);
       lcd.print((char)255);
     }
@@ -646,7 +804,7 @@ void releaseCamera() {
     delay( releaseTime * 1000 );
     digitalWrite(12, LOW);
 
-    if( currentMenu == SCR_RUNNING ){ // clear exposure indicator
+    if ( currentMenu == SCR_RUNNING ) { // clear exposure indicator
       lcd.setCursor(7, 1);
       lcd.print(" ");
     }
@@ -654,9 +812,9 @@ void releaseCamera() {
   } else { // releaseTime > 1 sec
 
     // long trigger in Bulb-Mode for longer exposures
-    if( bulbReleasedAt == 0 ){
-        bulbReleasedAt = millis();
-        digitalWrite(12, HIGH);
+    if ( bulbReleasedAt == 0 ) {
+      bulbReleasedAt = millis();
+      digitalWrite(12, HIGH);
     }
   }
 
@@ -665,14 +823,14 @@ void releaseCamera() {
 /**
   Will be called by the loop and check if a bulb exposure has to end. If so, it will stop the exposure.
 */
-void possiblyEndLongExposure(){
-  if( ( bulbReleasedAt != 0 ) && ( millis() >= ( bulbReleasedAt + releaseTime * 1000 ) ) ){
+void possiblyEndLongExposure() {
+  if ( ( bulbReleasedAt != 0 ) && ( millis() >= ( bulbReleasedAt + releaseTime * 1000 ) ) ) {
     bulbReleasedAt = 0;
     digitalWrite(12, LOW);
   }
 
-  if( currentMenu == SCR_RUNNING ){ // display exposure indicator on running screen only
-    if( bulbReleasedAt == 0 ) {
+  if ( currentMenu == SCR_RUNNING ) { // display exposure indicator on running screen only
+    if ( bulbReleasedAt == 0 ) {
       lcd.setCursor(7, 1);
       lcd.print(" ");
     } else {
@@ -681,7 +839,7 @@ void possiblyEndLongExposure(){
     }
   }
 
-  if( currentMenu == SCR_SINGLE ){
+  if ( currentMenu == SCR_SINGLE ) {
     printSingleScreen();
   }
 }
@@ -740,7 +898,7 @@ void printModeMenu() {
   lcd.setCursor(0, 0);
   lcd.print("Mode");
   lcd.setCursor(0, 1);
-  if( mode == MODE_M ){
+  if ( mode == MODE_M ) {
     lcd.print( "M (Default)     " );
   } else {
     lcd.print( "Bulb (Astro)    " );
@@ -828,10 +986,10 @@ void printConfirmEndScreenBulb() {
   lcd.print( "< Cont.   Stop >");
 }
 
-void printSingleScreen(){
+void printSingleScreen() {
   lcd.setCursor(0, 0);
 
-  if( releaseTime < 1 ){
+  if ( releaseTime < 1 ) {
     lcd.print( "Single Exposure");
     lcd.setCursor(0, 1);
     lcd.print(releaseTime); // under one second
@@ -840,7 +998,7 @@ void printSingleScreen(){
     lcd.print( "Bulb Exposure  ");
     lcd.setCursor(0, 1);
 
-    if( bulbReleasedAt == 0 ){ // if not shooting
+    if ( bulbReleasedAt == 0 ) { // if not shooting
       // display exposure time setting
       int hours = (int)releaseTime / 60 / 60;
       int minutes = ( (int)releaseTime / 60 ) % 60;
@@ -859,9 +1017,9 @@ void printSingleScreen(){
     }
   }
 
-  if( bulbReleasedAt == 0 ){ // currently not running
+  if ( bulbReleasedAt == 0 ) { // currently not running
 
-    lcd.setCursor(10,1);
+    lcd.setCursor(10, 1);
     lcd.print( "< FIRE" );
 
   } else { // running

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -1,3 +1,25 @@
+0.89
+Changes by Klaus Heiss, Austria
+- Introduces LCD backlight dimming for power saving and optical reason 
+  long pressing select key steps dimming level. release key at suitable level
+  when running: up down keys are increasing or decreasing brighness for your convenience
+  consumption at available brightness leveles to get an idea of possible power savings:
+  0 (OFF) 	 50 mA
+  1 min		 55 mA  (you may now let backlight on always at this level)
+  2		 70 mA
+  3		 88 mA
+  4		104 mA
+  5		115 mA
+  6		124 mA
+
+- Params can be saved in EEPROM
+  when backlight is turned on and pressing select key 2 times short and fast (double-pressing) these params are saved in EEPROM
+  - actual display background brightness level
+  - actual interval 
+  After power on or reset these values are restored from EEPROM
+  
+- Turned OFF Onboard LED 13. it only consumes battery power.
+
 0.88
 Changes by Klaus Heiss, Austria (Thank you!)
 - Introduces dynamic key repeating. This makes the keyboard more responsive.


### PR DESCRIPTION
0.89
Changes by Klaus Heiss, Austria
- Introduces LCD backlight dimming for power saving and optical reason 
  long pressing select key steps dimming level. release key at suitable level
  when running: up down keys are increasing or decreasing brighness for your convenience
  consumption at available brightness leveles to get an idea of possible power savings:
  0 (OFF) 	 50 mA
  1 min		 55 mA  (you may now let backlight on always at this level)
  2		 70 mA
  3		 88 mA
  4		104 mA
  5		115 mA
  6		124 mA

- Params can be saved in EEPROM
  when backlight is turned on and pressing select key 2 times short and fast (double-pressing) these params are saved in EEPROM
  - actual display background brightness level
  - actual interval 
  After power on or reset these values are restored from EEPROM
  
- Turned OFF Onboard LED 13. it only consumes battery power.